### PR TITLE
Better use_template usage.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # tidytuesdayR (development version)
 
+* [bug fix] `use_tidytemplate()` now explicitly takes an `ignore` argument, rather than passing (almost entirely overruled) `...` through to `usethis::use_template()`. (@jonthegeek, #76)
+
 # tidytuesdayR 1.1.2
 
 * [maintenance] tidytuesdayR now uses the {gh} package to manage all interactions with the GitHub API. This should make the package more stable and easier to maintain. (@jonthegeek, #78)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # tidytuesdayR (development version)
 
 * [bug fix] `use_tidytemplate()` now explicitly takes an `ignore` argument, rather than passing (almost entirely overruled) `...` through to `usethis::use_template()`. (@jonthegeek, #76)
+* [bug fix] Attempting to load data for particularly strange, early weeks (2018 weeks 7 and 8) now errors more informatively. (@jonthegeek, #90)
 
 # tidytuesdayR 1.1.2
 

--- a/R/tt_check_date.R
+++ b/R/tt_check_date.R
@@ -38,9 +38,9 @@ tt_check_date <- function(x, week = NULL, auth = gh::gh_token()) {
 tt_check_date.date <- function(x, auth = gh::gh_token()) {
   tt_year <- lubridate::year(x)
   tt_formatted_date <- tt_date_format(x)
-  if (as.character(tt_formatted_date) == "2018-05-15") {
+  if (as.character(tt_formatted_date) %in% c("2018-05-15", "2018-05-21")) {
     cli::cli_abort(
-      "The dataset for 2018-05-15 is dirty and cannot be automatically loaded.",
+      "The dataset for {tt_formatted_date} is dirty and cannot be automatically loaded.",
       class = "tt-error-invalid_date"
     )
   }
@@ -60,6 +60,13 @@ tt_check_date.date <- function(x, auth = gh::gh_token()) {
 }
 
 tt_check_date.year <- function(x, week, auth = gh::gh_token()) {
+  if (x == 2018 && week %in% c(7, 8)) {
+    cli::cli_abort(
+      "The dataset for 2018 week {week} is dirty and cannot be automatically loaded.",
+      class = "tt-error-invalid_date"
+    )
+  }
+
   tt_folders <- tt_weeks(x, auth = auth)
 
   if (!week %in% tt_folders$week_desc && week >= 1) {
@@ -83,7 +90,7 @@ tt_check_date.year <- function(x, week, auth = gh::gh_token()) {
   tt_date <- tt_folders$folders[tt_folders$week_desc == week]
 
   if (!tt_date %in% tt_folders[["folders"]] ||
-    !tt_folders[["data"]][tt_folders[["folders"]] == tt_date]) {
+      !tt_folders[["data"]][tt_folders[["folders"]] == tt_date]) {
     cli::cli_abort(
       "Week {week} of {x} does not have data available for download.",
       class = "tt-error-invalid_date"

--- a/R/tt_check_date.R
+++ b/R/tt_check_date.R
@@ -38,6 +38,13 @@ tt_check_date <- function(x, week = NULL, auth = gh::gh_token()) {
 tt_check_date.date <- function(x, auth = gh::gh_token()) {
   tt_year <- lubridate::year(x)
   tt_formatted_date <- tt_date_format(x)
+  if (as.character(tt_formatted_date) == "2018-05-15") {
+    cli::cli_abort(
+      "The dataset for 2018-05-15 is dirty and cannot be automatically loaded.",
+      class = "tt-error-invalid_date"
+    )
+  }
+
   tt_folders <- tt_weeks(tt_year, auth = auth)
   if (!as.character(tt_formatted_date) %in% tt_folders[["folders"]]) {
     closest <- tt_closest_date(tt_formatted_date, tt_folders$folders)

--- a/R/use_tidytemplate.R
+++ b/R/use_tidytemplate.R
@@ -3,10 +3,10 @@
 #' Use the tidytemplate Rmd for starting your analysis with a leg up for
 #' processing
 #'
-#' @param name name of your TidyTuesday analysis file
-#' @param open should the file be opened after being created
-#' @param ... arguments to be passed to [usethis::use_template()]
-#' @param refdate date to use as reference to determine which TidyTuesday to use
+#' @inheritParams usethis::use_template
+#' @param name A name for your generated TidyTuesday analysis Rmd, such as
+#'   "My_TidyTuesday.Rmd".
+#' @param refdate Date to use as reference to determine which TidyTuesday to use
 #'   for the template. Either date object or character string in YYYY-MM-DD
 #'   format.
 #'
@@ -19,22 +19,24 @@
 #'
 #' @export
 use_tidytemplate <- function(name = NULL,
-                             open = interactive(),
-                             ...,
-                             refdate = today()) {
-  stopifnot(inherits(refdate, "Date") | valid_date(refdate))
+                             open = rlang::is_interactive(),
+                             refdate = today(),
+                             ignore = FALSE) {
+  stopifnot(valid_date(refdate))
   last_tt <- last_tuesday(refdate)
-
   if (is.null(name)) {
     name <- paste0(format(last_tt, "%Y_%m_%d"), "_tidy_tuesday.Rmd")
   }
 
-  usethis::use_template("tidytemplate.Rmd",
+  usethis::use_template(
+    "tidytemplate.Rmd",
     save_as = name,
     data = list(
       call_date = today(),
       call_tuesday = format(last_tt, "%Y-%m-%d")
     ),
-    package = "tidytuesdayR", ..., open = open
+    package = "tidytuesdayR",
+    ignore = ignore,
+    open = open
   )
 }

--- a/man/use_tidytemplate.Rd
+++ b/man/use_tidytemplate.Rd
@@ -4,18 +4,25 @@
 \alias{use_tidytemplate}
 \title{Call and open the tidytemplate}
 \usage{
-use_tidytemplate(name = NULL, open = interactive(), ..., refdate = today())
+use_tidytemplate(
+  name = NULL,
+  open = rlang::is_interactive(),
+  refdate = today(),
+  ignore = FALSE
+)
 }
 \arguments{
-\item{name}{name of your TidyTuesday analysis file}
+\item{name}{A name for your generated TidyTuesday analysis Rmd, such as
+"My_TidyTuesday.Rmd".}
 
-\item{open}{should the file be opened after being created}
+\item{open}{Open the newly created file for editing? Happens in RStudio, if
+applicable, or via \code{\link[utils:file.edit]{utils::file.edit()}} otherwise.}
 
-\item{...}{arguments to be passed to \code{\link[usethis:use_template]{usethis::use_template()}}}
-
-\item{refdate}{date to use as reference to determine which TidyTuesday to use
+\item{refdate}{Date to use as reference to determine which TidyTuesday to use
 for the template. Either date object or character string in YYYY-MM-DD
 format.}
+
+\item{ignore}{Should the newly created file be added to \code{.Rbuildignore}?}
 }
 \value{
 A logical vector indicating whether the file was created or modified,

--- a/tests/testthat/test-tt_check_date.R
+++ b/tests/testthat/test-tt_check_date.R
@@ -82,3 +82,14 @@ test_that("tt_check_date errors informatively with no args", {
     class = "tt-error-invalid_date"
   )
 })
+
+test_that("tt_check_date errors informatively for the dirtiest dataset", {
+  local_tt_master_file()
+  expect_error(
+    {
+      tt_check_date("2018-05-15")
+    },
+    "cannot be automatically loaded",
+    class = "tt-error-invalid_date"
+  )
+})

--- a/tests/testthat/test-use_tidytemplate.R
+++ b/tests/testthat/test-use_tidytemplate.R
@@ -20,6 +20,7 @@ test_that("use_tidytemplate processes inputs", {
         call_tuesday = "2024-08-20"
       ),
       package = "tidytuesdayR",
+      ignore = FALSE,
       open = FALSE
     )
   )


### PR DESCRIPTION
There was only 1 `...` value in `use_tidytemplate()` that we didn't overrule (`ignore`), so we now explicitly name this argument. Technically changes the function signature for `use_tidytemplate()`, but anything that this breaks was already broken, so I'm not flagging this as a breaking change.

Closes #76.