### PR TITLE
Use usethis to avoid mac error on CRAN

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: tidytuesdayR
 Title: Access the Weekly 'TidyTuesday' Project Dataset
-Version: 1.2.0.9000
+Version: 1.2.1
 Authors@R: c(
     person("Jon", "Harmon", , "jonthegeek@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-4781-4346")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
-# tidytuesdayR (development version)
+# tidytuesdayR 1.2.1
+* [tests] No user-facing changes.
 
 # tidytuesdayR 1.2.0
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,3 +1,10 @@
 ## R CMD check results
 
-0 errors | 0 warnings | 0 notes
+0 errors | 0 warnings | 1 note
+
+Days since last update: 1
+
+Update to address check failures.
+
+* Updated 2 tests in test-tt_curate_utils.R to avoid previously undetected 
+  (despite testing with Mac runners) issues with paths on CRAN Mac runners.

--- a/tests/testthat/test-tt_curate_utils.R
+++ b/tests/testthat/test-tt_curate_utils.R
@@ -1,19 +1,19 @@
 test_that("prep_tt_curate creates the directory", {
   skip_on_ci()
   proj_dir <- withr::local_tempdir()
-  full_submission_path <- fs::path(proj_dir, "tt_submission")
   usethis::local_project(proj_dir, force = TRUE, quiet = TRUE)
+  full_submission_path <- usethis::proj_path("tt_submission")
   test_result <- prep_tt_curate()
-  expect_identical(test_result, full_submission_path)
+  expect_equal(test_result, full_submission_path)
 })
 
 test_that("prep_tt_curate works with ignore", {
   skip_on_ci()
   proj_dir <- withr::local_tempdir()
-  full_submission_path <- fs::path(proj_dir, "tt_submission")
   usethis::local_project(proj_dir, force = TRUE, quiet = TRUE)
+  full_submission_path <- usethis::proj_path("tt_submission")
   test_result <- prep_tt_curate(ignore = TRUE)
-  expect_identical(test_result, full_submission_path)
+  expect_equal(test_result, full_submission_path)
   ignore_path <- fs::path(proj_dir, ".Rbuildignore")
   expect_true(fs::file_exists(ignore_path))
   ignore_contents <- readLines(ignore_path)


### PR DESCRIPTION
Trying to avoid this error on CRAN mac machines:
```
actual vs expected
    - "/private/var/folders/2b/t0kwbtmn3p7brv2mvx39c9cr0000gn/T/RtmpWnKhtt/filea7f1d39079b/tt_submission"
    + "/var/folders/2b/t0kwbtmn3p7brv2mvx39c9cr0000gn/T/RtmpWnKhtt/filea7f1d39079b/tt_submission"
    ── Failure ('test-tt_curate_utils.R:16:3'): prep_tt_curate works with ignore ───
    `test_result` (`actual`) not identical to `full_submission_path` (`expected`).
```