### PR TITLE
Better error messaging for missing GH PAT.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
 # tidytuesdayR (development version)
+* [messaging] Added a clearer error message for missing github credentials (#135).
 
 # tidytuesdayR 1.2.1
 * [tests] No user-facing changes.

--- a/R/github_api.R
+++ b/R/github_api.R
@@ -14,6 +14,7 @@
 #' @returns The GitHub response as parsed by [gh::gh()].
 #' @keywords internal
 gh_get <- function(path, auth = gh::gh_token(), ...) {
+  auth <- gh_auth_check(auth)
   gh::gh(
     "/repos/:tt_repo/contents/:path",
     path = path,
@@ -71,6 +72,19 @@ gh_get_readme_html <- function(path, auth = gh::gh_token()) {
 }
 
 # Do not hit api ----
+
+gh_auth_check <- function(auth = gh::gh_token()) {
+  if (!nchar(auth)) {
+    cli::cli_abort(
+      c(
+        x = "{.arg auth} is not a valid github token.",
+        i = "See the {.vignette gh::managing-personal-access-tokens} vignette."
+      ),
+      class = "tt-error-bad_gh_auth"
+    )
+  }
+  return(auth)
+}
 
 gh_raw_to_chr <- function(encoded_raw) {
   return(rawToChar(jsonlite::base64_dec(encoded_raw)))

--- a/R/tt_submit.R
+++ b/R/tt_submit.R
@@ -21,6 +21,7 @@ tt_submit <- function(path = "tt_submission",
   rlang::check_installed("base64enc", "to prepare files for a submission.")
   files <- tt_find_dataset_files(path)
 
+  auth <- gh_auth_check(auth)
   user <- tt_user(auth = auth)
   repo <- getOption("tidytuesdayR.tt_repo", "rfordatascience/tidytuesday")
   branch <- tt_find_branch(path)

--- a/tests/testthat/test-github_api.R
+++ b/tests/testthat/test-github_api.R
@@ -101,3 +101,23 @@ test_that("gh_extract_sha_in_folder errors for missing file", {
     class = "tt-error-file_not_found"
   )
 })
+
+test_that("gh_auth_check makes sure auth looks valid", {
+  expect_error(
+    {
+      gh_auth_check("")
+    },
+    "is not a valid github token",
+    class = "tt-error-bad_gh_auth"
+  )
+  expect_error(
+    {
+      gh_auth_check(structure("", class = "gh_pat"))
+    },
+    "is not a valid github token",
+    class = "tt-error-bad_gh_auth"
+  )
+  expect_no_error({
+    gh_auth_check(structure("valid_token", class = "gh_pat"))
+  })
+})

--- a/tests/testthat/test-tt_submit.R
+++ b/tests/testthat/test-tt_submit.R
@@ -70,6 +70,9 @@ test_that("tt_find_branch deals with branch names", {
 
 test_that("tt_submit informs about the PR url", {
   local_mocked_bindings(
+    gh_auth_check = function(...) {
+      return("auth")
+    },
     tt_user = function(auth) {
       return("testuser")
     },


### PR DESCRIPTION
Closes #135.

@jenrichmond I don't know for certain if this is what you ran into, but it's my best guess. I'm marking your ticket closed with this, but let me know if you experience the issue again! You do *not* need to work inside an RStudio project with an associated github repo, so you shouldn't have to do anything like that to make this work!

Thanks again for trying out the new functionality!